### PR TITLE
Adds $ to URL regex

### DIFF
--- a/cmd/vl/main.go
+++ b/cmd/vl/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	urlRE      = regexp.MustCompile(`https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9]{1,6}\b([-a-zA-Z0-9!@:%_\+.~#?&\/\/=]*)`)
+	urlRE      = regexp.MustCompile(`https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9]{1,6}\b([-a-zA-Z0-9!@:%_\+.~#?&\/\/=$]*)`)
 	skipStatus = flag.String("a", "", "-a 500,400")
 	timeout    = flag.Duration("t", 10*time.Second, "-t 10s or -t 1h")
 	whitelist  = flag.String("w", "", "-w server1.com,server2.com")


### PR DESCRIPTION
I was trying to use this code to check URLs from Brazilian Federal Revenue, but some of them had a `$` in the URL, e.g.: `http://200.152.38.155/CNPJ/F.K03200$Z.D10510.MUNICCSV.zip` ([source](https://www.gov.br/receitafederal/pt-br/assuntos/orientacao-tributaria/cadastros/consultas/dados-publicos-cnpj)).

This was a bug for verify-links:

```
$ go run main.go /tmp/urls.txt
Found 38 URIs
[200] http://200.152.38.155/CNPJ/K3241.K03200Y0.D10510.EMPRECSV.zip
[200] http://200.152.38.155/CNPJ/K3241.K03200Y4.D10510.ESTABELE.zip
[200] http://200.152.38.155/CNPJ/K3241.K03200Y4.D10510.SOCIOCSV.zip
[200] http://200.152.38.155/CNPJ/K3241.K03200Y8.D10510.SOCIOCSV.zip
[200] http://200.152.38.155/CNPJ/K3241.K03200Y0.D10510.SOCIOCSV.zip
[404] http://200.152.38.155/CNPJ/F.K03200
…
```

(This last line was cut just at the `$`.)

I suggest we add `$` to the URL regex, which made this bug go away in this specific use case : )
